### PR TITLE
escape markdown in warn.ts

### DIFF
--- a/src/commands/Moderation/warn.ts
+++ b/src/commands/Moderation/warn.ts
@@ -1,4 +1,4 @@
-import { Message, Guild } from 'discord.js';
+import { Message, Guild, Util } from 'discord.js';
 import { commandInterface } from '../../commands';
 import { permLevels } from '../../utils/permissions';
 import { Bot } from '../..';
@@ -48,7 +48,7 @@ var command: commandInterface = {
 
             // send confirmation message
             Bot.mStats.logResponseTime(command.name, requestTime);
-            message.channel.send(`:white_check_mark: **${user.user.tag} has been warned, ${reason}**`);
+            message.channel.send(`:white_check_mark: **${user.user.tag} has been warned, ${Util.escapeMarkdown(reason)}**`);
             Bot.mStats.logCommandUsage(command.name);
             Bot.mStats.logMessageSend();
             return true;


### PR DESCRIPTION
normally when you warn someone if your reason includes ** markdown gets confused and it doesn't look good.
With this PR, the markdown will be escaped